### PR TITLE
Create glusto YAML config as part of the Vagrantfile invocation.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ disk_size = 501 #GB
 cpus = 2
 memory = 1024
 
-node_count = 3 # node-0 is our client.
+node_count = 4 # node-0 is our client.
 
 Vagrant.configure(2) do |config|
     puts "Creating #{node_count} nodes."
@@ -16,14 +16,43 @@ Vagrant.configure(2) do |config|
 
     require "fileutils"
     f = File.open("dist/hosts","w")
-        (0..node_count).each do |num|
+    g = File.open("dist/glusto.yml", "w")
+    (0..node_count).each do |num|
       f.puts "node-#{num} ansible_host=192.168.250.#{num+10}"
     end
     f.puts "[gluster_servers]"
+    g.puts "log_level: DEBUG"
+    g.puts "log_file: /tmp/gluster_tests.log"
+    g.puts "servers:"
     (1..node_count).each do |num|
       f.puts "node-#{num} ansible_host=192.168.250.#{num+10}"
+      g.puts "  - node-#{num} "
     end
+    g.puts "clients:\n\  - node-0"
+    g.puts "servers_info:"
+    (1..node_count).each do |num|
+      g.puts "  node-#{num}: &server#{num}"
+      g.puts "    host: 192.168.250.#{num+10}"
+      g.print "    devices: ["
+      (1..(node_data_disk_count - 1)).each do |d|
+        g.print "\"/dev/vd#{driveletters[d]}\", "
+      end
+      g.puts "/dev/vd#{driveletters[node_data_disk_count]}]"
+      g.puts "    brick_root: \"/mnt\""
+    end
+    g.puts "clients_info:"
+    g.puts "  node-0: &client1"
+    g.puts "    host: 192.168.250.10"
+    g.puts "\ngluster:"
+    g.puts "  volume_types:"
+    g.puts "    distributed_replicated: &distributed_replicated"
+    g.puts "      type: \"distributed-replicated\""
+    g.puts "      dist_count: 2"
+    g.puts "      replica_count: 2"
+    g.puts "      transport: \"tcp\""
     f.close
+    g.close
+
 
     (0..node_count).reverse_each do |num|
       config.vm.define "node-#{num}" do |node|
@@ -91,6 +120,9 @@ Vagrant.configure(2) do |config|
 
             echo "Running Gluster Ansible on node-0 to deploy Gluster..."
             PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_CONFIG='/vagrant/ansible.cfg' ansible-playbook --limit="gluster_servers" --inventory-file=/vagrant/hosts --extra-vars "node_count=#{node_count}" /vagrant/gluster.yml
+
+            echo "Cleaning up creatde volume, before running tests..."
+            PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_CONFIG='/vagrant/ansible.cfg' ansible-playbook --limit="gluster_servers" --inventory-file=/vagrant/hosts --extra-vars "node_count=#{node_count}" /vagrant/gluster-cleanup.yml
             SHELL
 	  end
         end

--- a/dist/gluster-cleanup.yml
+++ b/dist/gluster-cleanup.yml
@@ -1,0 +1,13 @@
+---
+- name: Setting up backend
+  remote_user: root
+  hosts: gluster_servers
+  vars:
+     gluster_cluster_hosts: "{{ groups['gluster_servers'] }}"
+     gluster_cluster_volume: 'testvol'
+     gluster_cluster_state: absent
+     #gluster_cluster_remove_bricks: '/mnt/thicklv/testvol,/mnt/thinlv1'
+
+  roles:
+     - gluster.cluster
+

--- a/dist/gluster.yml
+++ b/dist/gluster.yml
@@ -49,6 +49,7 @@
 
      gluster_cluster_hosts: "{{ groups['gluster_servers'] }}"
      gluster_cluster_volume: 'testvol'
+     gluster_cluster_status: absent
      gluster_cluster_transport: 'tcp'
      gluster_cluster_force: 'yes'
      gluster_cluster_bricks: '/mnt/thicklv/testvol,/mnt/thinlv1'


### PR DESCRIPTION
Not a complete solution, but seems reasonable:
create the Glusto basic YAML file as part of the Vagrantfile.

In addition, try to cleanup the 'testvol' created.
The volume is removed - next phase would be to remove the bricks
and the mounts and the LVs, let Glusto take over from scratch.